### PR TITLE
add support for local directory as a backend

### DIFF
--- a/go-nix/libstore/binary_cache.go
+++ b/go-nix/libstore/binary_cache.go
@@ -35,6 +35,8 @@ func NewBinaryCacheReader(ctx context.Context, storeURL string) (BinaryCacheRead
 		return NewGCSBinaryCacheStore(ctx, u)
 	case "s3":
 		return NewS3BinaryCacheStore(u)
+	case "file":
+		return NewFileBinaryCacheStore(u), nil
 	default:
 		return nil, fmt.Errorf("scheme %s is not supported", u.Scheme)
 	}

--- a/go-nix/libstore/file_binary_cache_store.go
+++ b/go-nix/libstore/file_binary_cache_store.go
@@ -1,0 +1,46 @@
+package libstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type FileBinaryCacheStore struct {
+	path string
+}
+
+func NewFileBinaryCacheStore(u *url.URL) FileBinaryCacheStore {
+	return FileBinaryCacheStore{u.Path}
+}
+
+func (c FileBinaryCacheStore) checkPath(p string) error {
+	if strings.HasPrefix(filepath.Clean(p), ".") {
+		return errors.New("relative paths are not allowed")
+	}
+	return nil
+}
+
+func (c FileBinaryCacheStore) FileExists(ctx context.Context, p string) (bool, error) {
+	if err := c.checkPath(p); err != nil {
+		return false, err
+	}
+	_, err := os.Open(path.Join(c.path, p))
+	return !os.IsNotExist(err), err
+}
+
+func (c FileBinaryCacheStore) GetFile(ctx context.Context, p string) (io.ReadCloser, error) {
+	if err := c.checkPath(p); err != nil {
+		return nil, err
+	}
+	return os.Open(path.Join(c.path, p))
+}
+
+func (c FileBinaryCacheStore) URL() string {
+	return "file://" + c.path
+}


### PR DESCRIPTION
This adds support for binary caches that are stored in a local
directory, similar to how nix supports local directories with `nix
copy`. They can be used by setting the binary cache URL to
`file:///path/to/cache`. This is especially useful when hosting a binary
cache and running nar-serve on the same host, because this eliminates
the need to transfer the nar over HTTP and possibly encrypting and
decrypting it when using TLS.