### PR TITLE
Update minimum required Go version to v1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /go/src/app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/numtide/nar-serve
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go/compute v1.6.0 // indirect


### PR DESCRIPTION
An indirect dependency on io/fs requires us to upgrade to Go 1.16