### PR TITLE
Expose the executable bit into a HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ unpack and serve any file in the cache on the fly.
 
 Inside the provided nix shell run:
 
-```
+```shell
 ./start-dev
 ```
 
@@ -26,12 +26,26 @@ Currently, the default port is 8383. You can change it by setting the `PORT` env
 
 ## Usage
 
+Store contents can be fetched via a simple HTTP GET request.
+
 Append any store path to the hostname to fetch and unpack it on
 the fly. That's it.
 
-Eg:
+E.g.:
 
 * https://nar-serve.zimbatm.now.sh/nix/store/barxv95b8arrlh97s6axj8k7ljn7aky1-go-1.12/share/go/doc/effective_go.html
+
+NAR archives also contain information about the executable bit for each contained file.
+nar-serve uses a custom HTTP header named `NAR-executable` to indicate whether the fetched file would be executable.
+
+## Configuration
+
+You can use the following environment variables to configure nar-serve:
+
+| Name | Default value | Description |
+|:--   |:--            |:-- |
+| `PORT` | `8383` | Port number on which nar-service listens |
+| `NAR_CACHE_URL` | `https://cache.nixos.org` | The URL of the Nix store from which NARs are fetched |
 
 ## Contributing
 
@@ -40,4 +54,4 @@ Contributions are welcome!
 Before adding any new feature it might be best to first discuss them by
 creating a new issue in https://github.com/numtide/nar-serve/issues .
 
-All code is licenses under the Apache 2.0 license.
+All code is licensed under the Apache 2.0 license.

--- a/api/unpack/index.go
+++ b/api/unpack/index.go
@@ -164,6 +164,10 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 					// TODO: use http.DetectContentType as a fallback
 				}
 
+				if hdr.Executable {
+					w.Header().Set("NAR-Executable", "1")
+				}
+
 				w.Header().Set("Cache-Control", "immutable")
 				w.Header().Set("Content-Type", ctype)
 				w.Header().Set("Content-Length", fmt.Sprintf("%d", hdr.Size))


### PR DESCRIPTION
I've implemented a header named NAR-Executable.

I decided against the X- prefix as its discouraged since [RFC6648](https://datatracker.ietf.org/doc/html/rfc6648).

Closes #2 