### PR TITLE
main: serve from the store the cache says it holds

### DIFF
--- a/api/unpack/index.go
+++ b/api/unpack/index.go
@@ -51,20 +51,35 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.ServeNAR(narHash, w, req)
 }
 
+// archivePath turns a request path into the path to look for inside the
+// archive, by taking off the mount path and the store path's own directory.
+// Trailing slashes are not significant.
+func archivePath(mountPath, urlPath string) string {
+	path := strings.TrimRight(urlPath, "/")
+
+	if strings.HasPrefix(path, mountPath) {
+		// The mount path is whatever store the cache holds paths for, which is
+		// not always `/nix/store`, so count its components rather than assume
+		// there are three. One more comes off for the store path itself.
+		skip := len(strings.Split(strings.TrimSuffix(mountPath, "/"), "/")) + 1
+
+		components := strings.Split(path, "/")
+		if len(components) > skip {
+			path = strings.Join(components[skip:], "/")
+		} else {
+			path = ""
+		}
+	}
+
+	return "/" + strings.TrimLeft(path, "/")
+}
+
 func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	log.Println("narHash=", narHash)
 
-	// Do some path cleanup
-	// ignore trailing slashes
-	newPath := strings.TrimRight(req.URL.Path, "/")
-	// remove the mount path and nar hash from the path
-	if strings.HasPrefix(newPath, h.mountPath) {
-		components := strings.Split(newPath, "/")
-		newPath = strings.Join(components[4:], "/")
-	}
-	newPath = "/" + strings.TrimLeft(newPath, "/")
+	newPath := archivePath(h.mountPath, req.URL.Path)
 	log.Println("newPath=", newPath)
 
 	// Get the NAR info to find the NAR

--- a/api/unpack/mountpath_test.go
+++ b/api/unpack/mountpath_test.go
@@ -1,0 +1,34 @@
+package unpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArchivePath(t *testing.T) {
+	for _, tt := range []struct {
+		mountPath string
+		urlPath   string
+		expected  string
+	}{
+		// The store path's own directory is not part of the path inside it.
+		{"/nix/store/", "/nix/store/00000000000000000000000000000000-example", "/"},
+		{"/nix/store/", "/nix/store/00000000000000000000000000000000-example/", "/"},
+		{"/nix/store/", "/nix/store/00000000000000000000000000000000-example/bin/sh", "/bin/sh"},
+		{"/nix/store/", "/nix/store/00000000000000000000000000000000-example/bin/sh/", "/bin/sh"},
+
+		// A store somewhere other than `/nix/store` is one component deeper,
+		// so a fixed count would cut the path in the wrong place.
+		{"/var/lib/nix/store/", "/var/lib/nix/store/00000000000000000000000000000000-example/bin/sh", "/bin/sh"},
+		{"/var/lib/nix/store/", "/var/lib/nix/store/00000000000000000000000000000000-example", "/"},
+
+		// Served by hash sub-domain, the request path is already the one
+		// inside the archive.
+		{"/nix/store/", "/bin/sh", "/bin/sh"},
+		{"/nix/store/", "/", "/"},
+	} {
+		assert.Equal(t, tt.expected, archivePath(tt.mountPath, tt.urlPath),
+			"archivePath(%q, %q)", tt.mountPath, tt.urlPath)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -52,8 +52,22 @@ func main() {
 		panic(err)
 	}
 
-	// FIXME: get the mountPath from the binary cache /nix-cache-info file
-	storeHandler := unpack.NewHandler(cache, "/nix/store/")
+	// Paths from a store at one prefix are not valid under another, so serve
+	// them from wherever the cache says its store is.
+	storeDir := libstore.DefaultStoreDir
+
+	cacheInfo, err := libstore.GetCacheInfo(context.Background(), cache)
+	if err != nil {
+		// Not every cache publishes the file, and one that does not is
+		// overwhelmingly likely to be a default store. Say so and carry on
+		// rather than refuse to start.
+		log.Printf("could not read %s from %s, assuming %s: %v",
+			libstore.CacheInfoPath, nixCacheURL, storeDir, err)
+	} else {
+		storeDir = cacheInfo.StoreDir
+	}
+
+	storeHandler := unpack.NewHandler(cache, strings.TrimSuffix(storeDir, "/")+"/")
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -106,6 +120,7 @@ func main() {
 
 	log.Println("domain=", domain)
 	log.Println("nixCacheURL=", nixCacheURL)
+	log.Println("storeDir=", storeHandler.MountPath())
 	log.Println("addr=", addr)
 	log.Fatal(http.ListenAndServe(addr, r))
 }

--- a/pkg/libstore/cache_info.go
+++ b/pkg/libstore/cache_info.go
@@ -1,0 +1,85 @@
+package libstore
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// DefaultStoreDir is the store a cache holds paths for unless it says otherwise.
+const DefaultStoreDir = "/nix/store"
+
+// CacheInfoPath is where a binary cache publishes its CacheInfo.
+const CacheInfoPath = "nix-cache-info"
+
+// CacheInfo is what a binary cache says about itself.
+type CacheInfo struct {
+	// StoreDir is the store the cached paths belong to. Paths from a store at
+	// one prefix are not valid under another, so this decides where a client
+	// may serve them from.
+	StoreDir string
+
+	// WantMassQuery is whether the cache is happy to be asked about paths it
+	// may not have.
+	WantMassQuery bool
+
+	// Priority orders this cache against others; the lower one is consulted
+	// first.
+	Priority int
+}
+
+// GetCacheInfo reads the cache's `nix-cache-info`.
+func GetCacheInfo(ctx context.Context, cache BinaryCacheReader) (*CacheInfo, error) {
+	f, err := cache.GetFile(ctx, CacheInfoPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return ParseCacheInfo(f)
+}
+
+// ParseCacheInfo reads the `Key: value` lines of a `nix-cache-info` file.
+// Unknown keys are skipped, since a cache may state more than a reader knows
+// to ask about.
+func ParseCacheInfo(r io.Reader) (*CacheInfo, error) {
+	info := &CacheInfo{StoreDir: DefaultStoreDir}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			return nil, fmt.Errorf("malformed %s line: %q", CacheInfoPath, line)
+		}
+
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "StoreDir":
+			info.StoreDir = value
+		case "WantMassQuery":
+			info.WantMassQuery = value == "1"
+		case "Priority":
+			priority, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("%s Priority: %w", CacheInfoPath, err)
+			}
+
+			info.Priority = priority
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}

--- a/pkg/libstore/cache_info_test.go
+++ b/pkg/libstore/cache_info_test.go
@@ -1,0 +1,91 @@
+package libstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCache is a BinaryCacheReader over a fixed set of files.
+type stubCache map[string]string
+
+func (c stubCache) FileExists(_ context.Context, path string) (bool, error) {
+	_, ok := c[path]
+
+	return ok, nil
+}
+
+func (c stubCache) GetFile(_ context.Context, path string) (io.ReadCloser, error) {
+	contents, ok := c[path]
+	if !ok {
+		return nil, fmt.Errorf("no such file: %s", path)
+	}
+
+	return io.NopCloser(strings.NewReader(contents)), nil
+}
+
+func (c stubCache) URL() string {
+	return "stub://"
+}
+
+func TestParseCacheInfo(t *testing.T) {
+	info, err := ParseCacheInfo(strings.NewReader(
+		"StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 40\n",
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/nix/store", info.StoreDir)
+	assert.True(t, info.WantMassQuery)
+	assert.Equal(t, 40, info.Priority)
+}
+
+func TestParseCacheInfoOtherStoreDir(t *testing.T) {
+	info, err := ParseCacheInfo(strings.NewReader("StoreDir: /var/lib/nix/store\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/var/lib/nix/store", info.StoreDir)
+}
+
+func TestParseCacheInfoDefaults(t *testing.T) {
+	// A cache that says nothing about its store holds the default one.
+	info, err := ParseCacheInfo(strings.NewReader("Priority: 30\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, DefaultStoreDir, info.StoreDir)
+	assert.False(t, info.WantMassQuery)
+}
+
+func TestParseCacheInfoIgnoresUnknownKeys(t *testing.T) {
+	info, err := ParseCacheInfo(strings.NewReader("StoreDir: /nix/store\nSomethingElse: 1\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/nix/store", info.StoreDir)
+}
+
+func TestParseCacheInfoRejectsMalformed(t *testing.T) {
+	_, err := ParseCacheInfo(strings.NewReader("StoreDir /nix/store\n"))
+	assert.Error(t, err)
+
+	_, err = ParseCacheInfo(strings.NewReader("Priority: soon\n"))
+	assert.Error(t, err)
+}
+
+func TestGetCacheInfo(t *testing.T) {
+	cache := stubCache{CacheInfoPath: "StoreDir: /var/lib/nix/store\nPriority: 41\n"}
+
+	info, err := GetCacheInfo(context.Background(), cache)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/var/lib/nix/store", info.StoreDir)
+	assert.Equal(t, 41, info.Priority)
+}
+
+func TestGetCacheInfoMissing(t *testing.T) {
+	_, err := GetCacheInfo(context.Background(), stubCache{})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Closes #3.

Addresses `FIXME` "get the mountPath from the binary cache /nix-cache-info file" in `main.go`.

A cache's `nix-cache-info` states which store its paths belong to, and a path from a store at one prefix is not valid under another. The mount path was fixed at `/nix/store/` regardless, so a cache for a store anywhere else was served under a prefix its paths never had.

`libstore` gains a reader for the file, and the mount path comes from it. A cache that publishes no such file is still served under `/nix/store`, since that is overwhelmingly what it will be, and saying so beats refusing to start.

Splitting a request path also assumed the store sat three components down, which only holds for the default; that count now comes from the mount path, and is what the added tests cover.

Assisted-by: Claude:claude-opus-5
