### PR TITLE
main: bound how many requests may walk an archive at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can use the following environment variables to configure nar-serve:
 | `HTTP_ADDR` | `:$PORT` | HTTP address to bind the server to. When set, takes precedence over $PORT. |
 | `NIX_CACHE_URL` | `https://cache.nixos.org` | The URL of the Nix store from which NARs are fetched |
 | `DOMAIN` | "" | When set, also serve `<nar-hash>.$DOMAIN` paths. |
+| `MAX_CONCURRENCY` | `0` | How many requests may walk an archive at once. Requests over the limit wait their turn. `0` does not limit anything. |
 
 ## Contributing
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -35,6 +36,35 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("OK"))
 }
 
+// limitConcurrency bounds how many requests may be walking an archive at once.
+// Decompressing up to the wanted file is the whole cost of a request, so this
+// is what keeps a burst of lookups from taking over the machine it runs on.
+// Requests over the limit wait their turn rather than being refused, and give
+// up only if the client does. A limit of zero or less does not restrict
+// anything.
+func limitConcurrency(limit int) func(http.Handler) http.Handler {
+	if limit <= 0 {
+		return func(next http.Handler) http.Handler { return next }
+	}
+
+	slots := make(chan struct{}, limit)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-r.Context().Done():
+				http.Error(w, "gave up waiting for a free slot", http.StatusRequestTimeout)
+
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func main() {
 	var (
 		port        = getEnv("PORT", "8383")
@@ -42,6 +72,11 @@ func main() {
 		nixCacheURL = getEnv("NIX_CACHE_URL", getEnv("NAR_CACHE_URL", "https://cache.nixos.org"))
 		domain      = getEnv("DOMAIN", "")
 	)
+
+	maxConcurrency, err := strconv.Atoi(getEnv("MAX_CONCURRENCY", "0"))
+	if err != nil {
+		log.Fatalf("MAX_CONCURRENCY: %v", err)
+	}
 
 	if addr == "" {
 		addr = ":" + port
@@ -54,6 +89,13 @@ func main() {
 
 	// FIXME: get the mountPath from the binary cache /nix-cache-info file
 	storeHandler := unpack.NewHandler(cache, "/nix/store/")
+
+	// Only the archive walk is worth limiting; `/healthz` and the index stay
+	// answerable however busy the rest of it is. One limiter, shared by both
+	// routes into the store, so the budget is for the process rather than per
+	// route.
+	limit := limitConcurrency(maxConcurrency)
+	limitedStoreHandler := limit(storeHandler)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -74,11 +116,12 @@ func main() {
 	})
 	defaultRouter.Get("/healthz", healthzHandler)
 	defaultRouter.Get("/robots.txt", robotsHandler)
-	defaultRouter.Method("GET", storeHandler.MountPath()+"{narDir}", storeHandler)
-	defaultRouter.Method("GET", storeHandler.MountPath()+"{narDir}/*", storeHandler)
+	defaultRouter.Method("GET", storeHandler.MountPath()+"{narDir}", limitedStoreHandler)
+	defaultRouter.Method("GET", storeHandler.MountPath()+"{narDir}/*", limitedStoreHandler)
 
 	if domain != "" {
 		narRouter := chi.NewRouter()
+		narRouter.Use(limit)
 		narRouter.Get("/*", func(w http.ResponseWriter, r *http.Request) {
 			// First try to find a nix hash in a subdomain.
 			narHash := getSubdomain(r.Host)
@@ -107,6 +150,7 @@ func main() {
 	log.Println("domain=", domain)
 	log.Println("nixCacheURL=", nixCacheURL)
 	log.Println("addr=", addr)
+	log.Println("maxConcurrency=", maxConcurrency)
 	log.Fatal(http.ListenAndServe(addr, r))
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The limiter has to hold the number of concurrent handlers at the limit, and
+// let every request through eventually rather than refusing the overflow.
+func TestLimitConcurrency(t *testing.T) {
+	const (
+		limit    = 2
+		requests = 10
+	)
+
+	var (
+		inFlight int32
+		peak     int32
+		release  = make(chan struct{})
+	)
+
+	handler := limitConcurrency(limit)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		now := atomic.AddInt32(&inFlight, 1)
+		for {
+			seen := atomic.LoadInt32(&peak)
+			if now <= seen || atomic.CompareAndSwapInt32(&peak, seen, now) {
+				break
+			}
+		}
+
+		<-release
+		atomic.AddInt32(&inFlight, -1)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var wg sync.WaitGroup
+
+	codes := make([]int, requests)
+
+	for i := range codes {
+		wg.Add(1)
+
+		// `go.mod` still asks for 1.21 semantics, where the loop variable is
+		// shared across iterations.
+		go func(i int) {
+			defer wg.Done()
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+			codes[i] = rec.Code
+		}(i)
+	}
+
+	// Let the first batch pile up against the limit before draining.
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inFlight) == limit
+	}, time.Second, time.Millisecond, "the limit should be reached")
+
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(limit), atomic.LoadInt32(&peak),
+		"no more than the limit should run at once")
+
+	for i, code := range codes {
+		assert.Equal(t, http.StatusOK, code, "request %d should have been served", i)
+	}
+}
+
+func TestLimitConcurrencyDisabled(t *testing.T) {
+	handler := limitConcurrency(0)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}


### PR DESCRIPTION
Decompressing up to the wanted file is the whole cost of a request, so a burst of lookups can take over the machine serving them. `MAX_CONCURRENCY` bounds how many requests may be walking an archive at once.

Requests over the limit wait their turn rather than being refused, and give up only if the client does. The default of `0` does not limit anything, so nothing changes unless it is set. One limiter is shared by both routes into the store, so the budget is for the process rather than per route, and `/healthz` and the index stay answerable however busy the rest of it is.

Assisted-by: Claude:claude-opus-5
