### PR TITLE
unpack: stop the scan once the archive is past the wanted path

### DIFF
--- a/api/unpack/index.go
+++ b/api/unpack/index.go
@@ -119,6 +119,7 @@ func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Requ
 		http.Error(w, err.Error(), 500)
 		return
 	}
+	defer narReader.Close()
 
 	for {
 		hdr, err := narReader.Next()
@@ -211,8 +212,15 @@ func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Requ
 			return
 		}
 
-		// TODO: since the nar entries are sorted it's possible to abort early by
-		//       comparing the paths
+		// NAR entries are ordered, so the wanted path can only appear while
+		// the scan is still short of where its name would sort. Once an entry
+		// comes back from beyond it, the archive does not contain the path and
+		// there is nothing to gain from decompressing the remainder.
+		if !nar.PathIsLexicographicallyOrdered(hdr.Path, newPath) {
+			http.Error(w, "file not found", 404)
+
+			return
+		}
 	}
 }
 

--- a/api/unpack/index.go
+++ b/api/unpack/index.go
@@ -89,6 +89,10 @@ func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Requ
 
 	// decompress on the fly
 	switch narinfo.Compression {
+	case "none":
+		// The NAR is stored verbatim. `narinfo.Parse` turns an absent
+		// `Compression` field into `bzip2` rather than this, so `none` only
+		// ever comes from a cache that states it.
 	case "xz":
 		r, err = xz.NewReader(r)
 		if err != nil {

--- a/api/unpack/index.go
+++ b/api/unpack/index.go
@@ -138,17 +138,24 @@ func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Requ
 				w.Header().Set("Content-Type", "text/html")
 				fmt.Fprintf(w, "<p>%s is a directory:</p><ol>", hdr.Path)
 				flush(w)
+
+				// The directory's own path is a prefix of its siblings' paths
+				// as well as its children's, so match against it with the
+				// separator attached: `/libexec` is not inside `/lib`. The
+				// root is already `/`, and trimming keeps it that way.
+				prefix := strings.TrimSuffix(hdr.Path, "/") + "/"
+
 				for {
 					hdr2, err := narReader.Next()
 					if err != nil {
-						if err == io.EOF {
-							break
-						} else {
+						if err != io.EOF {
 							http.Error(w, err.Error(), 500)
 						}
+
+						break
 					}
 
-					if !strings.HasPrefix(hdr2.Path, hdr.Path) {
+					if !strings.HasPrefix(hdr2.Path, prefix) {
 						break
 					}
 
@@ -161,7 +168,9 @@ func (h *Handler) ServeNAR(narHash string, w http.ResponseWriter, req *http.Requ
 					case nar.TypeRegular:
 						label = hdr2.Path
 					default:
-						http.Error(w, fmt.Sprintf("BUG: unknown NAR header type: %s", hdr.Type), 500)
+						http.Error(w, fmt.Sprintf("BUG: unknown NAR header type: %s", hdr2.Type), 500)
+
+						return
 					}
 
 					fmt.Fprintf(w, "<li><a href='%s'>%s</a></li>", filepath.Join(narinfo.StorePath, hdr2.Path), label)

--- a/api/unpack/index_test.go
+++ b/api/unpack/index_test.go
@@ -243,3 +243,14 @@ func TestServeMissingStorePath(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+func TestServeDirectoryListsOnlyItsChildren(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/lib"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), storePath("/lib/thing.so"))
+	assert.NotContains(t, rec.Body.String(), storePath("/libexec"),
+		"/libexec is a sibling of /lib, not a child of it")
+}

--- a/api/unpack/index_test.go
+++ b/api/unpack/index_test.go
@@ -130,8 +130,9 @@ func buildNAR(t *testing.T, entries []entry) []byte {
 // The fixture deliberately contains `/lib` next to `/libexec` and
 // `/share/applications` next to `/share/applications-extra`: both pairs are
 // ones where treating a path as a plain string prefix gets the answer wrong.
-// The large file at the end makes a full scan visibly more expensive than one
-// that stops where it can.
+// The large file sits under `/share/applications-extra`, immediately past the
+// point where a scan for something under `/share/applications` should give up,
+// so a scan that runs on pays for it in bytes a test can see.
 func testNAR(t *testing.T) []byte {
 	t.Helper()
 
@@ -147,9 +148,9 @@ func testNAR(t *testing.T) []byte {
 		{path: "/share/applications", dir: true},
 		{path: "/share/applications/example.desktop", contents: desktopEntry},
 		{path: "/share/applications-extra", dir: true},
-		{path: "/share/applications-extra/other", contents: "other"},
+		{path: "/share/applications-extra/big", contents: strings.Repeat("x", 1<<16)},
 		{path: "/share/doc", dir: true},
-		{path: "/share/doc/big", contents: strings.Repeat("x", 1<<16)},
+		{path: "/share/doc/readme", contents: "readme"},
 		{path: "/share/link", linkTo: "applications/example.desktop"},
 	})
 }
@@ -253,4 +254,38 @@ func TestServeDirectoryListsOnlyItsChildren(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), storePath("/lib/thing.so"))
 	assert.NotContains(t, rec.Body.String(), storePath("/libexec"),
 		"/libexec is a sibling of /lib, not a child of it")
+}
+
+func TestServeMissingFileStopsAtItsDirectory(t *testing.T) {
+	srv, cache := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/bin/absent"))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Less(t, cache.bytesRead(narURL), int64(len(testNAR(t)))/4,
+		"the scan should give up at /bin rather than read to the end")
+}
+
+// `/share/applications-extra` follows everything under
+// `/share/applications`, so reaching it means the wanted path has been
+// passed -- even though `-` is below `/` as a byte and a plain string
+// comparison says otherwise.
+func TestServeMissingFileStopsAtSimilarlyNamedSibling(t *testing.T) {
+	srv, cache := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/share/applications/zzz.desktop"))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Less(t, cache.bytesRead(narURL), int64(len(testNAR(t)))/2,
+		"the scan should give up at /share/applications-extra")
+}
+
+// A path sorting after every entry cannot be ruled out until the archive
+// runs out, which still has to answer rather than hang.
+func TestServeMissingFileAfterLastEntry(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/zzz"))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/api/unpack/index_test.go
+++ b/api/unpack/index_test.go
@@ -1,0 +1,245 @@
+package unpack_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/numtide/nar-serve/api/unpack"
+	"github.com/numtide/nar-serve/pkg/nar"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	storeDir  = "/nix/store/"
+	storeHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	storeName = storeHash + "-example-1.0"
+	narURL    = "nar/example.nar"
+
+	desktopEntry = "[Desktop Entry]\nName=Example\n"
+)
+
+// memCache is an in-memory BinaryCacheReader that records how much of each
+// file was read, so a test can tell a full scan from one that stopped early.
+type memCache struct {
+	files map[string][]byte
+	read  map[string]*int64
+}
+
+func newMemCache(files map[string][]byte) *memCache {
+	cache := &memCache{files: files, read: map[string]*int64{}}
+	for name := range files {
+		var n int64
+
+		cache.read[name] = &n
+	}
+
+	return cache
+}
+
+func (c *memCache) URL() string { return "mem://" }
+
+func (c *memCache) FileExists(_ context.Context, path string) (bool, error) {
+	_, ok := c.files[path]
+
+	return ok, nil
+}
+
+func (c *memCache) GetFile(_ context.Context, path string) (io.ReadCloser, error) {
+	body, ok := c.files[path]
+	if !ok {
+		return nil, fmt.Errorf("no such file: %s", path)
+	}
+
+	return &countingReader{r: bytes.NewReader(body), n: c.read[path]}, nil
+}
+
+// bytesRead reports how many bytes of path were pulled out of the cache.
+func (c *memCache) bytesRead(path string) int64 {
+	return atomic.LoadInt64(c.read[path])
+}
+
+type countingReader struct {
+	r io.Reader
+	n *int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	atomic.AddInt64(c.n, int64(n))
+
+	return n, err
+}
+
+func (c *countingReader) Close() error { return nil }
+
+// entry describes one NAR member. A zero linkTo and dir make it a regular
+// file, whatever contents says.
+type entry struct {
+	path     string
+	contents string
+	linkTo   string
+	dir      bool
+}
+
+func buildNAR(t *testing.T, entries []entry) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	narWriter, err := nar.NewWriter(&buf)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		hdr := &nar.Header{Path: e.path}
+
+		switch {
+		case e.dir:
+			hdr.Type = nar.TypeDirectory
+		case e.linkTo != "":
+			hdr.Type = nar.TypeSymlink
+			hdr.LinkTarget = e.linkTo
+		default:
+			hdr.Type = nar.TypeRegular
+			hdr.Size = int64(len(e.contents))
+		}
+
+		require.NoError(t, narWriter.WriteHeader(hdr))
+
+		if hdr.Type == nar.TypeRegular {
+			_, err := io.WriteString(narWriter, e.contents)
+			require.NoError(t, err)
+		}
+	}
+
+	require.NoError(t, narWriter.Close())
+
+	return buf.Bytes()
+}
+
+// The fixture deliberately contains `/lib` next to `/libexec` and
+// `/share/applications` next to `/share/applications-extra`: both pairs are
+// ones where treating a path as a plain string prefix gets the answer wrong.
+// The large file at the end makes a full scan visibly more expensive than one
+// that stops where it can.
+func testNAR(t *testing.T) []byte {
+	t.Helper()
+
+	return buildNAR(t, []entry{
+		{path: "/", dir: true},
+		{path: "/bin", dir: true},
+		{path: "/bin/example", contents: "#!/bin/sh\n"},
+		{path: "/lib", dir: true},
+		{path: "/lib/thing.so", contents: "lib"},
+		{path: "/libexec", dir: true},
+		{path: "/libexec/helper", contents: "helper"},
+		{path: "/share", dir: true},
+		{path: "/share/applications", dir: true},
+		{path: "/share/applications/example.desktop", contents: desktopEntry},
+		{path: "/share/applications-extra", dir: true},
+		{path: "/share/applications-extra/other", contents: "other"},
+		{path: "/share/doc", dir: true},
+		{path: "/share/doc/big", contents: strings.Repeat("x", 1<<16)},
+		{path: "/share/link", linkTo: "applications/example.desktop"},
+	})
+}
+
+func newServer(t *testing.T) (http.Handler, *memCache) {
+	t.Helper()
+
+	narinfo := fmt.Sprintf("StorePath: %s%s\nURL: %s\nCompression: none\n",
+		storeDir, storeName, narURL)
+
+	cache := newMemCache(map[string][]byte{
+		storeHash + ".narinfo": []byte(narinfo),
+		narURL:                 testNAR(t),
+	})
+
+	handler := unpack.NewHandler(cache, storeDir)
+
+	router := chi.NewRouter()
+	router.Use(middleware.CleanPath)
+	router.Use(middleware.GetHead)
+	router.Method("GET", handler.MountPath()+"{narDir}", handler)
+	router.Method("GET", handler.MountPath()+"{narDir}/*", handler)
+
+	return router, cache
+}
+
+func get(t *testing.T, srv http.Handler, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+
+	return rec
+}
+
+func storePath(sub string) string {
+	return storeDir + storeName + sub
+}
+
+func TestServeRegularFile(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/share/applications/example.desktop"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, desktopEntry, rec.Body.String())
+	assert.Equal(t, fmt.Sprint(len(desktopEntry)), rec.Header().Get("Content-Length"))
+}
+
+func TestServeHeadOmitsBody(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "HEAD", storePath("/share/applications/example.desktop"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Body.String())
+	assert.Equal(t, fmt.Sprint(len(desktopEntry)), rec.Header().Get("Content-Length"))
+}
+
+func TestServeFileInFirstDirectory(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/bin/example"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "#!/bin/sh\n", rec.Body.String())
+}
+
+func TestServeSymlinkRedirects(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/share/link"))
+
+	assert.Equal(t, http.StatusMovedPermanently, rec.Code)
+	assert.Equal(t, storePath("/share/applications/example.desktop"),
+		rec.Header().Get("Location"))
+}
+
+func TestServeMissingFile(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storePath("/share/applications/absent.desktop"))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestServeMissingStorePath(t *testing.T) {
+	srv, _ := newServer(t)
+
+	rec := get(t, srv, "GET", storeDir+"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-absent/bin/x")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -45,6 +45,9 @@ type Reader struct {
 	// NarReader uses this to resume the parser
 	next chan bool
 
+	// whether Close() has already signalled the parser
+	closed bool
+
 	// keep a record of the previously received hdr.Path.
 	// Only read and updated in the Next() method, receiving from the channel
 	// populated by the goroutine, not the goroutine itself.
@@ -69,9 +72,12 @@ func NewReader(r io.Reader) (*Reader, error) {
 		contentReader: io.NopCloser(io.LimitReader(bytes.NewReader([]byte{}), 0)),
 
 		headers: make(chan *Header),
-		errors:  make(chan error),
-		err:     nil,
-		next:    make(chan bool),
+		// Buffered, so the parser can deposit its final error and exit even
+		// when nobody is going to receive it. A consumer that stops reading
+		// part-way through and calls Close() is exactly that case.
+		errors: make(chan error, 1),
+		err:    nil,
+		next:   make(chan bool),
 	}
 
 	// kick off the goroutine
@@ -321,7 +327,23 @@ func (nr *Reader) Next() (*Header, error) {
 
 	// return either an error or headers
 	select {
-	case hdr := <-nr.headers:
+	case hdr, ok := <-nr.headers:
+		// The parser closes both channels when it is done, so by the time this
+		// select runs the outcome may be waiting on either one. A closed
+		// headers channel means there is no header and the verdict is on the
+		// other.
+		if !ok {
+			err := <-nr.errors
+			if err == nil {
+				err = io.EOF
+			}
+
+			// blow fuse
+			nr.err = err
+
+			return nil, err
+		}
+
 		if !PathIsLexicographicallyOrdered(nr.previousHdrPath, hdr.Path) {
 			err := fmt.Errorf("received header in the wrong order, %v <= %v", hdr.Path, nr.previousHdrPath)
 
@@ -356,11 +378,17 @@ func (nr *Reader) Read(b []byte) (int, error) {
 }
 
 // Close does all internal cleanup. It doesn't close the underlying reader (which can be any io.Reader).
+// It is safe to call more than once, so a consumer can defer it and still
+// close explicitly.
 func (nr *Reader) Close() error {
-	if nr.err != io.EOF {
-		// Signal the parser there won't be any next.
-		close(nr.next)
+	if nr.closed || nr.err == io.EOF {
+		return nil
 	}
+
+	nr.closed = true
+
+	// Signal the parser there won't be any next.
+	close(nr.next)
 
 	return nil
 }

--- a/pkg/nar/reader_test.go
+++ b/pkg/nar/reader_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/numtide/nar-serve/pkg/nar"
 	"github.com/stretchr/testify/assert"
@@ -364,4 +366,31 @@ func TestReaderSmoketest(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_ = nr.Close()
 	}, "closing the reader multiple times shouldn't panic")
+}
+
+// A consumer that stops part-way through the archive and closes the reader
+// must not leave the parser goroutine behind. The parser reports the end of
+// the archive on the errors channel after it unwinds, and when nothing is
+// left to receive that it has to be able to deposit it and exit anyway.
+func TestReaderCloseReleasesParser(t *testing.T) {
+	const readers = 50
+
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < readers; i++ {
+		nr, err := nar.NewReader(bytes.NewBuffer(genEmptyDirectoryNar()))
+		assert.NoError(t, err)
+
+		// Take the root entry, then walk away without reaching the end.
+		_, err = nr.Next()
+		assert.NoError(t, err)
+
+		assert.NoError(t, nr.Close())
+		assert.NoError(t, nr.Close(), "Close should be safe to call twice")
+	}
+
+	// The parsers unwind asynchronously, so let them be counted.
+	assert.Eventually(t, func() bool {
+		return runtime.NumGoroutine() < before+readers/2
+	}, time.Second, 10*time.Millisecond, "parser goroutines should have exited")
 }

--- a/pkg/nar/util.go
+++ b/pkg/nar/util.go
@@ -10,10 +10,6 @@ func IsValidNodeName(nodeName string) bool {
 
 // PathIsLexicographicallyOrdered checks if two paths are lexicographically ordered component by component.
 func PathIsLexicographicallyOrdered(path1 string, path2 string) bool {
-	if path1 <= path2 {
-		return true
-	}
-
 	// n is the lower number of characters of the two paths.
 	var n int
 	if len(path1) < len(path2) {
@@ -27,8 +23,18 @@ func PathIsLexicographicallyOrdered(path1 string, path2 string) bool {
 			continue
 		}
 
-		if path1[i] == '/' && path2[i] != '/' {
+		// A `/` terminates a path component, and entries are ordered by
+		// component. So whichever path ends its component here sorts first,
+		// whatever the other one continues with: `/a/b` precedes `/a-b`
+		// because the entry `a` precedes the entry `a-b`. This has to be
+		// decided before comparing the bytes themselves, since `/` is neither
+		// the lowest nor the highest byte that can appear in a name.
+		if path1[i] == '/' {
 			return true
+		}
+
+		if path2[i] == '/' {
+			return false
 		}
 
 		return path1[i] < path2[i]

--- a/pkg/nar/util_test.go
+++ b/pkg/nar/util_test.go
@@ -39,6 +39,24 @@ var cases = []struct {
 		path2:    "/cmd/structlayout-ao/main.go",
 		expected: false,
 	},
+	// The entry `structlayout` sorts before `structlayout-optimize`, so
+	// everything under it comes first. `-` is below `/` as a byte, so a plain
+	// string comparison gets this pair backwards.
+	{
+		path1:    "/cmd/structlayout-optimize",
+		path2:    "/cmd/structlayout/main.go",
+		expected: false,
+	},
+	{
+		path1:    "/share/applications-extra/a",
+		path2:    "/share/applications/a.desktop",
+		expected: false,
+	},
+	{
+		path1:    "/share/applications/a.desktop",
+		path2:    "/share/applications-extra/a",
+		expected: true,
+	},
 }
 
 func TestLexicographicallyOrdered(t *testing.T) {
@@ -47,6 +65,39 @@ func TestLexicographicallyOrdered(t *testing.T) {
 			result := nar.PathIsLexicographicallyOrdered(testCase.path1, testCase.path2)
 			assert.Equal(t, result, testCase.expected)
 		})
+	}
+}
+
+// The ordering has to be a total order, or the reader will reject NARs that
+// are in fact well formed. For every pair of distinct paths exactly one
+// direction holds, and every path is ordered with respect to itself.
+func TestLexicographicallyOrderedIsTotal(t *testing.T) {
+	paths := []string{
+		"/",
+		"/bin",
+		"/bin/hello",
+		"/share",
+		"/share/applications",
+		"/share/applications/a.desktop",
+		"/share/applications-extra",
+		"/share/applications-extra/a",
+		"/share/applications.d",
+		"/share/doc",
+	}
+
+	for _, p1 := range paths {
+		for _, p2 := range paths {
+			forwards := nar.PathIsLexicographicallyOrdered(p1, p2)
+			backwards := nar.PathIsLexicographicallyOrdered(p2, p1)
+
+			if p1 == p2 {
+				assert.True(t, forwards, "%q should be ordered with itself", p1)
+				continue
+			}
+
+			assert.NotEqual(t, forwards, backwards,
+				"exactly one of (%q, %q) and (%q, %q) should hold", p1, p2, p2, p1)
+		}
 	}
 }
 


### PR DESCRIPTION
This is the `TODO` in `api/unpack/index.go`: the handler decompressed the whole NAR even when the wanted path was absent, or sat near the front.

NAR entries are ordered, so the wanted path can only appear while the scan is still short of where its name would sort. Once an entry comes back from beyond it, the archive does not contain the path and there is nothing to gain from decompressing the remainder. Asking `cache.nixos.org` for a file a Go toolchain's store path does not have went from reading 62 MB and inflating the whole 227 MB NAR to reading 32 KB and inflating 1 KB.

Three fixes have to come first, so they are commits in the same PR:

- `PathIsLexicographicallyOrdered` compared bytes directly, but NAR entries are ordered by component, and `/` is neither the lowest nor the highest byte a name can contain. `/a/b` sorts before `/a-b`, because the entry `a` sorts before the entry `a-b`; a byte comparison gets that backwards, and `-` and `.` are both common in store paths. The abort decides on this relation, so until it is total the abort answers 404 for files that are there.
- A `Reader` whose consumer stopped part-way through leaked its parser goroutine: the final error send was unbuffered, so the parser blocked forever on a channel nobody was left to read. Every aborted scan is such a consumer.
  Buffering it lets the parser deposit its error and exit, and `Close` is now safe to call twice, so the handler can defer it.
- A cache that states `Compression: none` serves the NAR verbatim; that case returned an error, and it is what the tests serve from.

`api/unpack` had no tests, so this adds them, and with them one more fix they turned up: listing a directory matched entries by string prefix, so `/lib` swallowed everything under `/libexec`. The same loop also dereferenced a nil header and named the wrong variable in its error.

Each fix has a test that fails without it. The abort is asserted by counting the bytes read from the cache.

Also touches on #1's idea to limit the cost for missing files (tho without using `.ls`, nor creating directory listings).

Assisted-by: Claude:claude-opus-5
