### PR TITLE
Update nixpkgs pin and swap out minio dep

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768886240,
-        "narHash": "sha256-C2TjvwYZ2VDxYWeqvvJ5XPPp6U7H66zeJlRaErJKoEM=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "80e4adbcf8992d3fd27ad4964fbb84907f9478b0",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,9 @@
       systems,
     }:
     let
-      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+      # `nixpkgs` 26.11 dropped `x86_64-darwin`.
+      supportedSystems = nixpkgs.lib.remove "x86_64-darwin" (import systems);
+      eachSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
     in
     {
       overlays.default = import ./overlay.nix;

--- a/shell.nix
+++ b/shell.nix
@@ -10,8 +10,7 @@ nixpkgs.mkShell {
     gopls
     goreleaser
     golangci-lint
-    minio
-    minio-client
+    rclone
     reflex
     awscli
     google-cloud-sdk

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,18 +1,19 @@
 # Tests
 
-## With the minio package
+## Serve a bucket
+
+A bucket is a directory below the one being served, so creating it is creating
+that directory.
 
 ```shell
-mkdir nar
-minio server ./nar
+mkdir -p nar/nsbucket
+rclone serve s3 ./nar --addr 127.0.0.1:9000 --auth-key accesskey,secretkey
 ```
 
-## With the pkgs.minio-client package
+## Fill it
 
 ```shell
-mc config host add mycloud http://127.0.0.1:9000 accesskey secretkey
-mc mb mycloud/nar
-AWS_ACCESS_KEY_ID=accesskey AWS_SECRET_ACCESS_KEY=secretkey nix copy --to "s3://nar?region=eu-west-1&endpoint=127.0.0.1:9000&scheme=http" /nix/store/irfa91bs2wfqyh2j9kl8m3rcg7h72w4m-curl-7.71.1-bin
+AWS_ACCESS_KEY_ID=accesskey AWS_SECRET_ACCESS_KEY=secretkey nix copy --to "s3://nsbucket?region=us-east-1&endpoint=127.0.0.1:9000&scheme=http" /nix/store/irfa91bs2wfqyh2j9kl8m3rcg7h72w4m-curl-7.71.1-bin
 ```
 
 ## Run the test

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3,11 +3,14 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/numtide/nar-serve/pkg/libstore"
 	"github.com/stretchr/testify/assert"
@@ -22,51 +25,69 @@ func cmd(env []string, name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// waitForServer blocks until addr accepts connections, or gives up.
+func waitForServer(addr string) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			return conn.Close()
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%s never came up: %w", addr, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func TestHappyPath(t *testing.T) {
 	assert := assert.New(t)
 	accessKeyID := "Q3AM3UQ867SPQQA43P2F"
 	secretAccessKey := "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
 
+	addr := "127.0.0.1:9000"
+
 	tempDir, err := ioutil.TempDir("", "nar-serve")
-	homeDir := tempDir + "/home"
-	configDir := tempDir + "/config"
-	dataDir := tempDir + "/data"
-
-	env := append(os.Environ(),
-		"AWS_ACCESS_KEY_ID="+accessKeyID,
-		"AWS_SECRET_ACCESS_KEY="+secretAccessKey,
-		"MINIO_ACCESS_KEY="+accessKeyID,
-		"MINIO_SECRET_KEY="+secretAccessKey,
-		"MINIO_REGION_NAME=us-east-1",
-		"HOME="+homeDir,
-	)
-
 	if err != nil {
 		t.Fatal("tmpdir error:", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Start the server
-	minios := cmd(env, "minio", "server", dataDir, "--config-dir", configDir)
-	err = minios.Start()
+	dataDir := tempDir + "/data"
+	homeDir := tempDir + "/home"
+
+	// `nix copy` remembers per store URL which paths that store holds, and this
+	// one is served from a directory that is empty every run.
+	env := append(os.Environ(),
+		"AWS_ACCESS_KEY_ID="+accessKeyID,
+		"AWS_SECRET_ACCESS_KEY="+secretAccessKey,
+		"HOME="+homeDir,
+	)
+
+	// A bucket is a directory below the one being served, so creating it is
+	// creating that directory.
+	err = os.MkdirAll(filepath.Join(dataDir, "nsbucket"), 0o755)
 	if err != nil {
-		t.Fatal("minio error:", err)
+		t.Fatal("bucket error:", err)
+	}
+
+	// Start the server
+	server := cmd(env, "rclone", "serve", "s3", dataDir,
+		"--addr", addr,
+		"--auth-key", accessKeyID+","+secretAccessKey,
+	)
+	err = server.Start()
+	if err != nil {
+		t.Fatal("rclone error:", err)
 	}
 	defer func() {
-		minios.Process.Kill()
-		minios.Wait()
+		server.Process.Kill()
+		server.Wait()
 	}()
 
-	minioc := cmd(env, "mc", "config", "host", "add", "narcloud", "http://127.0.0.1:9000", accessKeyID, secretAccessKey, "--config-dir", configDir, "--api", "s3v4")
-	err = minioc.Run()
+	err = waitForServer(addr)
 	if err != nil {
-		t.Fatal("mc error:", err)
-	}
-
-	minio_bucket := cmd(env, "mc", "mb", "narcloud/nsbucket")
-	err = minio_bucket.Run()
-	if err != nil {
-		t.Fatal("mc error:", err)
+		t.Fatal("rclone error:", err)
 	}
 
 	nix_copy := cmd(env, "nix", "copy", "--to", "s3://nsbucket?region=us-east-1&endpoint=127.0.0.1:9000&scheme=http", "/nix/store/irfa91bs2wfqyh2j9kl8m3rcg7h72w4m-curl-7.71.1-bin")
@@ -120,5 +141,5 @@ func TestHappyPath(t *testing.T) {
 	}
 	assert.True(is_exist, "File is not existed")
 	// Stop the server
-	minios.Process.Kill()
+	server.Process.Kill()
 }


### PR DESCRIPTION
Update the `nixpkgs` pin, so `nix-shell` and `nix flake check` work again on a current `nixpkgs`.

Three parts:

- **Update the pin.** On the old pin `nix-shell` still evaluates, but on a current `nixpkgs-unstable` it aborts: `minio` is marked insecure and abandoned.
- **Swap `minio` for `rclone` in the test fixtures.** Updating the pin alone does not make `nix-shell` pass -- it only surfaces the vulnerability. `rclone serve s3` gives the integration test the same S3 fixture store without the abandoned dependency.
- **Drop `x86_64-darwin` from the flake's system list.** `nixpkgs` 26.11 removed that platform, so all three flake outputs for it fail to *evaluate* on the new pin. The remaining three systems (`aarch64-darwin`, `aarch64-linux`, `x86_64-linux`) are unaffected. This is a user-visible change riding along with a dependency update, but it is not avoidable: any bump past that removal hits it. The `systems` input is kept, so a downstream flake can still override the list.
